### PR TITLE
v2.0.0

### DIFF
--- a/MooseSoft.Azure.ServiceBus.sln
+++ b/MooseSoft.Azure.ServiceBus.sln
@@ -13,7 +13,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MooseSoft.Azure.ServiceBus.
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{F9AF4DF3-CD1A-47A3-9117-3708D2D29D73}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureFunctionSample", "samples\AzureFunctionSample\AzureFunctionSample.csproj", "{6714BE22-F62A-4D19-A8C4-40098081D894}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AzureFunctionSample", "samples\AzureFunctionSample\AzureFunctionSample.csproj", "{6714BE22-F62A-4D19-A8C4-40098081D894}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8E1A9EA3-8607-41D2-AE7D-A92EA67AA9AD}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/MooseSoft.Azure.ServiceBus.sln
+++ b/MooseSoft.Azure.ServiceBus.sln
@@ -20,6 +20,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MessagePumpConsoleSample", "samples\MessagePumpConsoleSample\MessagePumpConsoleSample.csproj", "{56DECBC5-33A5-4B83-9356-AEA24A69ABB7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,6 +40,10 @@ Global
 		{6714BE22-F62A-4D19-A8C4-40098081D894}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6714BE22-F62A-4D19-A8C4-40098081D894}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6714BE22-F62A-4D19-A8C4-40098081D894}.Release|Any CPU.Build.0 = Release|Any CPU
+		{56DECBC5-33A5-4B83-9356-AEA24A69ABB7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{56DECBC5-33A5-4B83-9356-AEA24A69ABB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{56DECBC5-33A5-4B83-9356-AEA24A69ABB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{56DECBC5-33A5-4B83-9356-AEA24A69ABB7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -46,6 +52,7 @@ Global
 		{FA824792-53BC-4256-BE94-D08070C268EB} = {C14D30AB-983A-4DAA-A8A0-C5EE6A4C3F60}
 		{41FC161F-7E49-44DF-8523-EA19478257A3} = {372263FB-0C5C-4054-BF91-33BB81755756}
 		{6714BE22-F62A-4D19-A8C4-40098081D894} = {F9AF4DF3-CD1A-47A3-9117-3708D2D29D73}
+		{56DECBC5-33A5-4B83-9356-AEA24A69ABB7} = {F9AF4DF3-CD1A-47A3-9117-3708D2D29D73}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0EC4DEFE-1C76-4C17-8B81-40B23F28D56A}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## What is it?
 
-Moosesoft.Azure.Servicebus is a .Net Standard 2.0 library that extends the functionality of [Microsoft.Azure.Service](https://github.com/Azure/azure-service-bus) by adding a failure policies to automatically handle any message processing failures.  Failure policies can be configured to use different back off delay strategies for resending messages back to originating queues/topics.
+Moosesoft.Azure.Servicebus is a .Net Standard 2.0 library that extends the functionality of [Microsoft.Azure.Service](https://github.com/Azure/azure-service-bus) by adding failure policies to automatically handle any message processing failures.  Failure policies can be configured to use different back off delay strategies for resending messages back to originating queues/topics.
 
 For more information please visit the [wiki](https://github.com/gtmoose32/moosesoft-azure-servicebus/wiki).
 

--- a/samples/AzureFunctionSample/AzureFunctionSample.csproj
+++ b/samples/AzureFunctionSample/AzureFunctionSample.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <AzureFunctionsVersion>v2</AzureFunctionsVersion>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="3.0.6" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="4.1.1" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MooseSoft.Azure.ServiceBus\MooseSoft.Azure.ServiceBus.csproj" />

--- a/samples/AzureFunctionSample/SampleFunction.cs
+++ b/samples/AzureFunctionSample/SampleFunction.cs
@@ -25,8 +25,7 @@ namespace AzureFunctionSample
         {
             MessageContextProcessor = new MessageContextProcessor(
                 new SampleMessageProcessor(),
-                new DeferMessageFailurePolicy(ex => true,
-                    backOffDelayStrategy: ExponentialBackOffDelayStrategy.Default));
+                new CloneMessageFailurePolicy(ex => true, ExponentialBackOffDelayStrategy.Default));
         }
 
         [FunctionName("SampleFunction")]

--- a/samples/AzureFunctionSample/SampleMessageProcessor.cs
+++ b/samples/AzureFunctionSample/SampleMessageProcessor.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Azure.ServiceBus;
 using MooseSoft.Azure.ServiceBus.Abstractions;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,8 +15,7 @@ namespace AzureFunctionSample
     {
         public Task ProcessMessageAsync(Message message, CancellationToken cancellationToken)
         {
-            //TODO: Add real processing logic
-            return Task.CompletedTask;
+            throw new InvalidOperationException("Test failure policy with back off delay strategy.");
         }
     }
 }

--- a/samples/MessagePumpConsoleSample/MessagePumpConsoleSample.csproj
+++ b/samples/MessagePumpConsoleSample/MessagePumpConsoleSample.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MooseSoft.Azure.ServiceBus\MooseSoft.Azure.ServiceBus.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/MessagePumpConsoleSample/Program.cs
+++ b/samples/MessagePumpConsoleSample/Program.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Azure.ServiceBus;
+using Microsoft.Azure.ServiceBus.Core;
+using MooseSoft.Azure.ServiceBus;
+using MooseSoft.Azure.ServiceBus.BackOffDelayStrategy;
+using MooseSoft.Azure.ServiceBus.FailurePolicy;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+
+namespace MessagePumpConsoleSample
+{
+    [ExcludeFromCodeCoverage]
+    class Program
+    {
+        static void Main()
+        {
+            var connection = new ServiceBusConnection("Endpoint=sb://somesbns.servicebus.windows.net/;SharedAccessKeyName=some-key;SharedAccessKey=fjsdjfkjsdakfjaskfjdskljfkdlsaf=");
+            
+            var contextProcessor = new MessageContextProcessor(
+                new SampleMessageProcessor(),
+                new DeferMessageFailurePolicy(e => true, new ZeroBackOffDelayStrategy()));
+
+            var receiver = new MessageReceiver(connection, "test");
+            //Add deferred message plugin
+            receiver.AddDeferredMessagePlugin();
+            //Setup message pump to use message context processor with defer failure policy.
+            receiver.RegisterMessageHandler(
+                (message, token) => contextProcessor.ProcessMessageContextAsync(new MessageContext(message, receiver), token), 
+                ExceptionReceivedHandler);
+
+    		Console.WriteLine("Press any key to terminate!");
+            Console.Read();
+        }
+
+        private static Task ExceptionReceivedHandler(ExceptionReceivedEventArgs arg)
+        {
+            //Handle any exception that might bubble up from the message pump however this shouldn't really happen 
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/samples/MessagePumpConsoleSample/SampleMessageProcessor.cs
+++ b/samples/MessagePumpConsoleSample/SampleMessageProcessor.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Azure.ServiceBus;
+using MooseSoft.Azure.ServiceBus.Abstractions;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MessagePumpConsoleSample
+{
+    /// <summary>
+    /// This class should contain code custom code necessary to "process" the message received from Service Bus
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class SampleMessageProcessor : IMessageProcessor
+    {
+        public Task ProcessMessageAsync(Message message, CancellationToken cancellationToken)
+        {
+            throw new InvalidOperationException("Test failure policy with back off delay strategy.");
+        }
+    }
+}

--- a/src/MooseSoft.Azure.ServiceBus/Abstractions/FailurePolicyBase.cs
+++ b/src/MooseSoft.Azure.ServiceBus/Abstractions/FailurePolicyBase.cs
@@ -21,12 +21,11 @@ namespace MooseSoft.Azure.ServiceBus.Abstractions
 
         private readonly Func<Exception, bool> _canHandle;
 
-        protected FailurePolicyBase(Func<Exception, bool> canHandle, int maxDeliveryCount = 10, IBackOffDelayStrategy backOffDelayStrategy = null)
+        protected FailurePolicyBase(Func<Exception, bool> canHandle, IBackOffDelayStrategy backOffDelayStrategy = null, int maxDeliveryCount = 10)
         {
             _canHandle = canHandle;
-            MaxDeliveryCount = maxDeliveryCount >= 0 ? maxDeliveryCount : 10;
             BackOffDelayStrategy = backOffDelayStrategy ?? new ZeroBackOffDelayStrategy();
-
+            MaxDeliveryCount = maxDeliveryCount >= 0 ? maxDeliveryCount : 10;
         }
 
         public bool CanHandle(Exception exception) => _canHandle(exception);

--- a/src/MooseSoft.Azure.ServiceBus/Abstractions/IMessageContextProcessor.cs
+++ b/src/MooseSoft.Azure.ServiceBus/Abstractions/IMessageContextProcessor.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 namespace MooseSoft.Azure.ServiceBus.Abstractions
 {
     /// <summary>
-    /// Defines an object that processes a <see cref="MessageContext"./>
+    /// Defines an object that processes a <see cref="MessageContext"/>
     /// </summary>
     public interface IMessageContextProcessor
     {

--- a/src/MooseSoft.Azure.ServiceBus/BackOffDelayStrategy/ConstantBackOffDelayStrategy.cs
+++ b/src/MooseSoft.Azure.ServiceBus/BackOffDelayStrategy/ConstantBackOffDelayStrategy.cs
@@ -17,11 +17,6 @@ namespace MooseSoft.Azure.ServiceBus.BackOffDelayStrategy
             _backOffDelay = backOffDelayTime >= TimeSpan.Zero ? backOffDelayTime : DefaultBackOffDelayTime;
         }
 
-        public ConstantBackOffDelayStrategy(int backOffDelayMinutes)
-        {
-            _backOffDelay = TimeSpan.FromMinutes(backOffDelayMinutes >= 0 ? backOffDelayMinutes : DefaultBackOffDelayTime.Minutes);
-        }
-
         /// <inheritdoc cref="IBackOffDelayStrategy"/>
         public TimeSpan Calculate(int attempts) => _backOffDelay;
 

--- a/src/MooseSoft.Azure.ServiceBus/BackOffDelayStrategy/ExponentialBackOffDelayStrategy.cs
+++ b/src/MooseSoft.Azure.ServiceBus/BackOffDelayStrategy/ExponentialBackOffDelayStrategy.cs
@@ -22,15 +22,6 @@ namespace MooseSoft.Azure.ServiceBus.BackOffDelayStrategy
             _maxDelay = maxDelayTime > TimeSpan.Zero ? maxDelayTime : DefaultMaxDelayTime;
         }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="maxDelayMinutes"></param>
-        public ExponentialBackOffDelayStrategy(int maxDelayMinutes)
-        {
-            _maxDelay = TimeSpan.FromMinutes(maxDelayMinutes > 0 ? maxDelayMinutes : DefaultMaxDelayTime.Minutes);
-        }
-
         /// <inheritdoc cref="IBackOffDelayStrategy"/>
         public virtual TimeSpan Calculate(int attempts)
             => new[] { TimeSpan.FromSeconds(100 * Math.Pow(attempts, 2)), _maxDelay }.Min();

--- a/src/MooseSoft.Azure.ServiceBus/BackOffDelayStrategy/LinearBackOffDelayStrategy.cs
+++ b/src/MooseSoft.Azure.ServiceBus/BackOffDelayStrategy/LinearBackOffDelayStrategy.cs
@@ -8,19 +8,19 @@ namespace MooseSoft.Azure.ServiceBus.BackOffDelayStrategy
     /// </summary>
     public class LinearBackOffDelayStrategy : IBackOffDelayStrategy
     {
-        private readonly int _multiplier;
+        private readonly TimeSpan _initialDelay;
 
-        public LinearBackOffDelayStrategy(int multiplier)
+        public LinearBackOffDelayStrategy(TimeSpan initialDelay)
         {
-            _multiplier = multiplier;
+            _initialDelay = initialDelay;
         }
 
         /// <inheritdoc cref="IBackOffDelayStrategy"/>
-        public virtual TimeSpan Calculate(int attempts) => TimeSpan.FromMinutes(_multiplier * attempts);
+        public virtual TimeSpan Calculate(int attempts) => TimeSpan.FromSeconds(_initialDelay.TotalSeconds * attempts);
 
         /// <summary>
         /// Creates an instance of this back off delay strategy with default settings.
         /// </summary>
-        public static IBackOffDelayStrategy Default => new LinearBackOffDelayStrategy(2);
+        public static IBackOffDelayStrategy Default => new LinearBackOffDelayStrategy(TimeSpan.FromMinutes(1));
     }
 }

--- a/src/MooseSoft.Azure.ServiceBus/Constants.cs
+++ b/src/MooseSoft.Azure.ServiceBus/Constants.cs
@@ -2,7 +2,7 @@
 {
     internal class Constants
     {
-        public const string DeferredKey = "DeferredSequenceNumber";
+        public const string DeferredKey = "deferred-message-locator";
         public const string RetryCountKey = "RetryCount";
     }
 }

--- a/src/MooseSoft.Azure.ServiceBus/DeferredMessagePlugin.cs
+++ b/src/MooseSoft.Azure.ServiceBus/DeferredMessagePlugin.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Azure.ServiceBus;
+using Microsoft.Azure.ServiceBus.Core;
+using System.Threading.Tasks;
+
+namespace MooseSoft.Azure.ServiceBus
+{
+    public class DeferredMessagePlugin : ServiceBusPlugin
+    {
+        private readonly IMessageReceiver _messageReceiver;
+        public override string Name => nameof(DeferredMessagePlugin);
+
+        public DeferredMessagePlugin(IMessageReceiver messageReceiver)
+        {
+            _messageReceiver = messageReceiver;
+        }
+
+        public override Task<Message> AfterMessageReceive(Message message)
+        {
+            return _messageReceiver.GetDeferredMessageAsync(message);
+        }
+    }
+}

--- a/src/MooseSoft.Azure.ServiceBus/FailurePolicy/CloneMessageFailurePolicy.cs
+++ b/src/MooseSoft.Azure.ServiceBus/FailurePolicy/CloneMessageFailurePolicy.cs
@@ -16,9 +16,9 @@ namespace MooseSoft.Azure.ServiceBus.FailurePolicy
     {
         public CloneMessageFailurePolicy(
             Func<Exception, bool> canHandle, 
-            int maxDeliveryCount = 10, 
-            IBackOffDelayStrategy backOffDelayStrategy = null)
-            : base(canHandle, maxDeliveryCount, backOffDelayStrategy)
+            IBackOffDelayStrategy backOffDelayStrategy = null, 
+            int maxDeliveryCount = 10)
+            : base(canHandle, backOffDelayStrategy, maxDeliveryCount)
         {
         } 
 

--- a/src/MooseSoft.Azure.ServiceBus/FailurePolicy/DeferMessageFailurePolicy.cs
+++ b/src/MooseSoft.Azure.ServiceBus/FailurePolicy/DeferMessageFailurePolicy.cs
@@ -32,15 +32,14 @@ namespace MooseSoft.Azure.ServiceBus.FailurePolicy
                 return;
             }
 
-            var deferredPointer = context.Message.CreateDeferredLocatorMessage(
-                BackOffDelayStrategy.Calculate(deliveryCount));
+            var messageLocator = context.Message.CreateDeferredMessageLocator(BackOffDelayStrategy.Calculate(deliveryCount));
 
             var sender = context.CreateMessageSender();
             try
             {
                 using (var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                 {
-                    await sender.SendAsync(deferredPointer).ConfigureAwait(false);
+                    await sender.SendAsync(messageLocator).ConfigureAwait(false);
                     await context.MessageReceiver.DeferAsync(context.Message.SystemProperties.LockToken)
                         .ConfigureAwait(false);
                     scope.Complete();

--- a/src/MooseSoft.Azure.ServiceBus/FailurePolicy/DeferMessageFailurePolicy.cs
+++ b/src/MooseSoft.Azure.ServiceBus/FailurePolicy/DeferMessageFailurePolicy.cs
@@ -15,9 +15,9 @@ namespace MooseSoft.Azure.ServiceBus.FailurePolicy
     {
         public DeferMessageFailurePolicy(
             Func<Exception, bool> canHandle, 
-            int maxDeliveryCount = 10, 
-            IBackOffDelayStrategy backOffDelayStrategy = null) 
-            : base(canHandle, maxDeliveryCount, backOffDelayStrategy)
+            IBackOffDelayStrategy backOffDelayStrategy = null,
+            int maxDeliveryCount = 10) 
+            : base(canHandle, backOffDelayStrategy, maxDeliveryCount)
         {
         } 
 

--- a/src/MooseSoft.Azure.ServiceBus/MessageContextProcessor.cs
+++ b/src/MooseSoft.Azure.ServiceBus/MessageContextProcessor.cs
@@ -1,7 +1,6 @@
 ﻿using MooseSoft.Azure.ServiceBus.Abstractions;
 using MooseSoft.Azure.ServiceBus.FailurePolicy;
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -53,7 +52,7 @@ namespace MooseSoft.Azure.ServiceBus
 
         private static async Task CheckForDeferredMessageAsync(MessageContext context)
         {
-            if (context.MessageReceiver.RegisteredPlugins.Any(p => p.Name == nameof(DeferredMessagePlugin))) return;
+            if (!context.Message.IsDeferredMessageLocator()) return;
 
             context.Message = await context.MessageReceiver.GetDeferredMessageAsync(context.Message);
         }

--- a/src/MooseSoft.Azure.ServiceBus/MessageContextProcessor.cs
+++ b/src/MooseSoft.Azure.ServiceBus/MessageContextProcessor.cs
@@ -15,11 +15,11 @@ namespace MooseSoft.Azure.ServiceBus
         private readonly Func<Exception, bool> _shouldComplete;
         
         /// <summary>
-        /// 
+        /// Creates a new instance of <see cref="MessageContextProcessor"/>
         /// </summary>
-        /// <param name="messageProcessor"></param>
-        /// <param name="failurePolicy"></param>
-        /// <param name="shouldComplete"></param>
+        /// <param name="messageProcessor">The object that will process the incoming message.</param>
+        /// <param name="failurePolicy">Failure policy that will potentially be applied to any message processing failures.</param>
+        /// <param name="shouldComplete">Function that determines whether the message should be completed on certain exception(s).</param>
         public MessageContextProcessor(
             IMessageProcessor messageProcessor, 
             IFailurePolicy failurePolicy = null, 

--- a/src/MooseSoft.Azure.ServiceBus/MessageReceiverExtensions.cs
+++ b/src/MooseSoft.Azure.ServiceBus/MessageReceiverExtensions.cs
@@ -24,13 +24,12 @@ namespace MooseSoft.Azure.ServiceBus
 
         internal static async Task<Message> GetDeferredMessageAsync(this IMessageReceiver messageReceiver, Message message)
         {
-            var sequenceNumber = message.GetDeferredSequenceNumber();
-            if (!sequenceNumber.HasValue) return message;
+            if (!message.TryGetDeferredSequenceNumber(out var sequenceNumber)) return message;
 
             using (var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
             {
                 await messageReceiver.CompleteAsync(message.SystemProperties.LockToken).ConfigureAwait(false);
-                message = await messageReceiver.ReceiveDeferredMessageAsync(sequenceNumber.Value)
+                message = await messageReceiver.ReceiveDeferredMessageAsync(sequenceNumber)
                     .ConfigureAwait(false);
 
                 scope.Complete();

--- a/src/MooseSoft.Azure.ServiceBus/MessageReceiverExtensions.cs
+++ b/src/MooseSoft.Azure.ServiceBus/MessageReceiverExtensions.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.Azure.ServiceBus;
+using Microsoft.Azure.ServiceBus.Core;
+using System.Threading.Tasks;
+using System.Transactions;
+
+namespace MooseSoft.Azure.ServiceBus
+{
+    public static class MessageReceiverExtensions
+    {
+        public static IMessageReceiver AddDeferredMessagePlugin(this IMessageReceiver messageReceiver)
+        {
+            messageReceiver.RegisterPlugin(new DeferredMessagePlugin(messageReceiver));
+
+            return messageReceiver;
+        }
+
+        public static async Task<Message> GetDeferredMessageAsync(this IMessageReceiver messageReceiver, Message message)
+        {
+            var sequenceNumber = message.GetDeferredSequenceNumber();
+            if (!sequenceNumber.HasValue) return message;
+
+            using (var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                await messageReceiver.CompleteAsync(message.SystemProperties.LockToken).ConfigureAwait(false);
+                message = await messageReceiver.ReceiveDeferredMessageAsync(sequenceNumber.Value)
+                    .ConfigureAwait(false);
+
+                scope.Complete();
+            }
+
+            return message;
+        }
+    }
+}

--- a/src/MooseSoft.Azure.ServiceBus/MessageReceiverExtensions.cs
+++ b/src/MooseSoft.Azure.ServiceBus/MessageReceiverExtensions.cs
@@ -5,8 +5,16 @@ using System.Transactions;
 
 namespace MooseSoft.Azure.ServiceBus
 {
+    /// <summary>
+    /// Class that defines extension methods for Azure Service Bus <see cref="IMessageReceiver"/>
+    /// </summary>
     public static class MessageReceiverExtensions
     {
+        /// <summary>
+        /// Adds a <see cref="DeferredMessagePlugin"/> to the <see cref="IMessageReceiver"/> list of registered plugins.  This will handle any deferred message failure policy actions.
+        /// </summary>
+        /// <param name="messageReceiver">The message receiver to register the <see cref="ServiceBusPlugin"/> to.</param>
+        /// <returns><see cref="IMessageReceiver"/></returns>
         public static IMessageReceiver AddDeferredMessagePlugin(this IMessageReceiver messageReceiver)
         {
             messageReceiver.RegisterPlugin(new DeferredMessagePlugin(messageReceiver));
@@ -14,7 +22,7 @@ namespace MooseSoft.Azure.ServiceBus
             return messageReceiver;
         }
 
-        public static async Task<Message> GetDeferredMessageAsync(this IMessageReceiver messageReceiver, Message message)
+        internal static async Task<Message> GetDeferredMessageAsync(this IMessageReceiver messageReceiver, Message message)
         {
             var sequenceNumber = message.GetDeferredSequenceNumber();
             if (!sequenceNumber.HasValue) return message;

--- a/src/MooseSoft.Azure.ServiceBus/MooseSoft.Azure.ServiceBus.csproj
+++ b/src/MooseSoft.Azure.ServiceBus/MooseSoft.Azure.ServiceBus.csproj
@@ -22,6 +22,7 @@ Changes in 2.0.0
 * ConstantBackOffDelayStrategy and ExponentialBackOffDelayStrategy have both had ctor removed that was no longer necessary.
 * Reordered ctor params for failure policy classes to reflect likely usage.
 * LinearBackOffDelayStrategy now accepts a TimeSpan as ctor argument instead of Int32 to give more flexibility.
+* Deferred locator messages now use Label and CorrelationId properties from the Message class to identify and locate deferred messages instead of custom key/value in UserProperties.
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/MooseSoft.Azure.ServiceBus/MooseSoft.Azure.ServiceBus.csproj
+++ b/src/MooseSoft.Azure.ServiceBus/MooseSoft.Azure.ServiceBus.csproj
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>1.0.2</Version>
+    <Version>2.0.0-prerelease1</Version>
     <Authors>Marty Mathis</Authors>
     <Company />
-    <Description>Provides classes to facilitate advanced message processing scenarios using Microsoft Azure Service Bus, including retry with back delay handling.</Description>
+    <Description>Provides classes to facilitate advanced message processing scenarios using Microsoft Azure Service Bus, including retry with back off delay handling.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/gtmoose32/moosesoft-azure-servicebus</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
@@ -14,11 +14,17 @@
     <PackageTags>azure service bus retry delay backoff message receiver queue topic</PackageTags>
     <NeutralLanguage>en-US</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageReleaseNotes>Updated Delay Strategies to take TimeSpan as input instead of minutes in constructor.</PackageReleaseNotes>
+    <DocumentationFile Condition="'$(Configuration)'=='Release'">bin\Release\netstandard2.0\MooseSoft.Azure.ServiceBus.xml</DocumentationFile>
+    <PackageReleaseNotes>
+Changes in 2.0.0
+* Added ServiceBusPlugin to handle defer message failure policy and extension method to register the plugin.
+* Added an optional should complete on exception func to MessageContextProcessor ctor that determines whether a message should be completed on an exception.
+* ConstantBackOffDelayStrategy and ExponentialBackOffDelayStrategy have both had ctor removed that was no longer necessary.
+    </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.4.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
   </ItemGroup>
 
 </Project>

--- a/src/MooseSoft.Azure.ServiceBus/MooseSoft.Azure.ServiceBus.csproj
+++ b/src/MooseSoft.Azure.ServiceBus/MooseSoft.Azure.ServiceBus.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>2.0.0-prerelease1</Version>
+    <Version>2.0.0</Version>
     <Authors>Marty Mathis</Authors>
     <Company />
     <Description>Provides classes to facilitate advanced message processing scenarios using Microsoft Azure Service Bus, including retry with back off delay handling.</Description>
@@ -20,6 +20,8 @@ Changes in 2.0.0
 * Added ServiceBusPlugin to handle defer message failure policy and extension method to register the plugin.
 * Added an optional should complete on exception func to MessageContextProcessor ctor that determines whether a message should be completed on an exception.
 * ConstantBackOffDelayStrategy and ExponentialBackOffDelayStrategy have both had ctor removed that was no longer necessary.
+* Reordered ctor params for failure policy classes to reflect likely usage.
+* LinearBackOffDelayStrategy now accepts a TimeSpan as ctor argument instead of Int32 to give more flexibility.
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/tests/MooseSoft.Azure.ServiceBus.Tests/BackOffDelayStrategy/LinearBackOffDelayStrategyTests.cs
+++ b/tests/MooseSoft.Azure.ServiceBus.Tests/BackOffDelayStrategy/LinearBackOffDelayStrategyTests.cs
@@ -1,9 +1,8 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MooseSoft.Azure.ServiceBus.BackOffDelayStrategy;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace MooseSoft.Azure.ServiceBus.Tests.BackOffDelayStrategy
 {
@@ -16,24 +15,16 @@ namespace MooseSoft.Azure.ServiceBus.Tests.BackOffDelayStrategy
         {
             //Arrange
             var sut = LinearBackOffDelayStrategy.Default;
-            var results = new List<TimeSpan>();
 
             //Act
+            var total = TimeSpan.Zero;
             for (var i = 1; i <= 10; i++)
             {
-                results.Add(sut.Calculate(i));
+                total += sut.Calculate(i);
             }
             
             //Assert
-            // ReSharper disable once CompareOfFloatsByEqualityOperator
-            Assert.IsTrue(results.All(ts => (ts.TotalMinutes % 2) == 0 ));
-
-            var previous = TimeSpan.Zero;
-            foreach (var ts in results)
-            {
-                Assert.AreEqual(previous + TimeSpan.FromMinutes(2), ts);
-                previous = ts;
-            }
+            total.TotalMinutes.Should().Be(55);
         }
     }
 }

--- a/tests/MooseSoft.Azure.ServiceBus.Tests/DeferredMessagePluginTests.cs
+++ b/tests/MooseSoft.Azure.ServiceBus.Tests/DeferredMessagePluginTests.cs
@@ -1,0 +1,44 @@
+﻿using FluentAssertions;
+using Microsoft.Azure.ServiceBus.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+
+namespace MooseSoft.Azure.ServiceBus.Tests
+{
+    [ExcludeFromCodeCoverage]
+    [TestClass]
+    public class DeferredMessagePluginTests : MessageTestBase
+    {
+        [TestMethod]
+        public async Task AfterMessageReceive_Test()
+        {
+            //Arrange
+            var receiver = Substitute.For<IMessageReceiver>();
+            var message = CreateMessage();
+            message.UserProperties.Add(Constants.DeferredKey, long.MaxValue);
+            var deferredMessage = CreateMessage();
+            receiver.ReceiveDeferredMessageAsync(long.MaxValue).Returns(deferredMessage);
+
+            var sut = new DeferredMessagePlugin(receiver);
+
+            //Act
+            var result = await sut.AfterMessageReceive(message).ConfigureAwait(false);
+
+            //Assert
+            result.Should().NotBeNull();
+            result.MessageId.Should().NotBeNullOrWhiteSpace()
+                .And
+                .Be(deferredMessage.MessageId);
+
+            result.SystemProperties.Should().NotBeNull();
+            result.SystemProperties.LockToken.Should().NotBeNullOrWhiteSpace()
+                .And
+                .Be(deferredMessage.SystemProperties.LockToken);
+
+            await receiver.Received().CompleteAsync(Arg.Is(message.SystemProperties.LockToken)).ConfigureAwait(false);
+            await receiver.Received().ReceiveDeferredMessageAsync(Arg.Is(long.MaxValue)).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/MooseSoft.Azure.ServiceBus.Tests/DeferredMessagePluginTests.cs
+++ b/tests/MooseSoft.Azure.ServiceBus.Tests/DeferredMessagePluginTests.cs
@@ -17,7 +17,9 @@ namespace MooseSoft.Azure.ServiceBus.Tests
             //Arrange
             var receiver = Substitute.For<IMessageReceiver>();
             var message = CreateMessage();
-            message.UserProperties.Add(Constants.DeferredKey, long.MaxValue);
+            message.Label = Constants.DeferredKey;
+            message.CorrelationId = long.MaxValue.ToString();
+
             var deferredMessage = CreateMessage();
             receiver.ReceiveDeferredMessageAsync(long.MaxValue).Returns(deferredMessage);
 
@@ -39,6 +41,21 @@ namespace MooseSoft.Azure.ServiceBus.Tests
 
             await receiver.Received().CompleteAsync(Arg.Is(message.SystemProperties.LockToken)).ConfigureAwait(false);
             await receiver.Received().ReceiveDeferredMessageAsync(Arg.Is(long.MaxValue)).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public void Name_Test()
+        {
+            //Arrange
+            var receiver = Substitute.For<IMessageReceiver>();
+            var sut = new DeferredMessagePlugin(receiver);
+
+            //Act
+            var result = sut.Name;
+
+            //Assert
+            result.Should().NotBeNull();
+            result.Should().Be(nameof(DeferredMessagePlugin));
         }
     }
 }

--- a/tests/MooseSoft.Azure.ServiceBus.Tests/MessageContextProcessorTests.cs
+++ b/tests/MooseSoft.Azure.ServiceBus.Tests/MessageContextProcessorTests.cs
@@ -61,7 +61,9 @@ namespace MooseSoft.Azure.ServiceBus.Tests
         {
             //Arrange
             var message = CreateMessage();
-            message.UserProperties.Add(Constants.DeferredKey, long.MaxValue);
+            message.Label = Constants.DeferredKey;
+            message.CorrelationId = long.MaxValue.ToString();
+
             var deferredMessage = CreateMessage();
             _messageReceiver.ReceiveDeferredMessageAsync(Arg.Is(long.MaxValue)).Returns(deferredMessage);
 

--- a/tests/MooseSoft.Azure.ServiceBus.Tests/MessageExtensionsTests.cs
+++ b/tests/MooseSoft.Azure.ServiceBus.Tests/MessageExtensionsTests.cs
@@ -1,0 +1,25 @@
+﻿using FluentAssertions;
+using Microsoft.Azure.ServiceBus;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MooseSoft.Azure.ServiceBus.Tests
+{
+    [ExcludeFromCodeCoverage]
+    [TestClass]
+    public class MessageExtensionsTests
+    {
+        [TestMethod]
+        public void TryGetDeferredSequenceNumber_NullCorrelationId_Test()
+        {
+            //Arrange
+            var sut = new Message();
+
+            //Act
+            var result = sut.TryGetDeferredSequenceNumber(out _);
+
+            //Assert
+            result.Should().BeFalse();
+        }
+    }
+}

--- a/tests/MooseSoft.Azure.ServiceBus.Tests/MessageReceiverExtensions.cs
+++ b/tests/MooseSoft.Azure.ServiceBus.Tests/MessageReceiverExtensions.cs
@@ -1,7 +1,9 @@
-﻿using Microsoft.Azure.ServiceBus.Core;
+﻿using Microsoft.Azure.ServiceBus;
+using Microsoft.Azure.ServiceBus.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 
 namespace MooseSoft.Azure.ServiceBus.Tests
 {
@@ -22,28 +24,19 @@ namespace MooseSoft.Azure.ServiceBus.Tests
             sut.Received().RegisterPlugin(Arg.Any<DeferredMessagePlugin>());
         }
 
-        //public static IMessageReceiver AddDeferredMessagePlugin(this IMessageReceiver messageReceiver)
-        //{
-        //    messageReceiver.RegisterPlugin(new DeferredMessagePlugin(messageReceiver));
+        [TestMethod]
+        public async Task GetDeferredMessageAsync_DeferredSequenceNumber_NotFound_Test()
+        {
+            //Arrange
+            var message = new Message();
+            var sut = Substitute.For<IMessageReceiver>();
 
-        //    return messageReceiver;
-        //}
+            //Act
+            var result = await sut.GetDeferredMessageAsync(message);
 
-        //public static async Task<Message> GetDeferredMessageAsync(this IMessageReceiver messageReceiver, Message message)
-        //{
-        //    var sequenceNumber = message.GetDeferredSequenceNumber();
-        //    if (!sequenceNumber.HasValue) return message;
-
-        //    using (var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
-        //    {
-        //        await messageReceiver.CompleteAsync(message.SystemProperties.LockToken).ConfigureAwait(false);
-        //        message = await messageReceiver.ReceiveDeferredMessageAsync(sequenceNumber.Value)
-        //            .ConfigureAwait(false);
-
-        //        scope.Complete();
-        //    }
-
-        //    return message;
-        //}
+            //Assert
+            await sut.DidNotReceiveWithAnyArgs().CompleteAsync(Arg.Any<string>()).ConfigureAwait(false);
+            await sut.DidNotReceiveWithAnyArgs().ReceiveDeferredMessageAsync(Arg.Any<long>()).ConfigureAwait(false);
+        }
     }
 }

--- a/tests/MooseSoft.Azure.ServiceBus.Tests/MessageReceiverExtensions.cs
+++ b/tests/MooseSoft.Azure.ServiceBus.Tests/MessageReceiverExtensions.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.Azure.ServiceBus.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MooseSoft.Azure.ServiceBus.Tests
+{
+    [ExcludeFromCodeCoverage]
+    [TestClass]
+    public class MessageReceiverExtensionsTests
+    {
+        [TestMethod]
+        public void AddDeferredMessagePlugin_Test()
+        {
+            //Arrange
+            var sut = Substitute.For<IMessageReceiver>();
+
+            //Act
+            sut.AddDeferredMessagePlugin();
+
+            //Assert
+            sut.Received().RegisterPlugin(Arg.Any<DeferredMessagePlugin>());
+        }
+
+        //public static IMessageReceiver AddDeferredMessagePlugin(this IMessageReceiver messageReceiver)
+        //{
+        //    messageReceiver.RegisterPlugin(new DeferredMessagePlugin(messageReceiver));
+
+        //    return messageReceiver;
+        //}
+
+        //public static async Task<Message> GetDeferredMessageAsync(this IMessageReceiver messageReceiver, Message message)
+        //{
+        //    var sequenceNumber = message.GetDeferredSequenceNumber();
+        //    if (!sequenceNumber.HasValue) return message;
+
+        //    using (var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+        //    {
+        //        await messageReceiver.CompleteAsync(message.SystemProperties.LockToken).ConfigureAwait(false);
+        //        message = await messageReceiver.ReceiveDeferredMessageAsync(sequenceNumber.Value)
+        //            .ConfigureAwait(false);
+
+        //        scope.Complete();
+        //    }
+
+        //    return message;
+        //}
+    }
+}

--- a/tests/MooseSoft.Azure.ServiceBus.Tests/MessageTestBase.cs
+++ b/tests/MooseSoft.Azure.ServiceBus.Tests/MessageTestBase.cs
@@ -14,7 +14,8 @@ namespace MooseSoft.Azure.ServiceBus.Tests
             var message = new Message
             {
                 Body = Encoding.UTF8.GetBytes("Test!"),
-                ContentType = "application/json"
+                ContentType = "application/json",
+                MessageId = Guid.NewGuid().ToString()
             };
 
             typeof(Message.SystemPropertiesCollection)

--- a/tests/MooseSoft.Azure.ServiceBus.Tests/MooseSoft.Azure.ServiceBus.Tests.csproj
+++ b/tests/MooseSoft.Azure.ServiceBus.Tests/MooseSoft.Azure.ServiceBus.Tests.csproj
@@ -8,10 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MooseSoft.Azure.ServiceBus.Tests/MooseSoft.Azure.ServiceBus.Tests.csproj
+++ b/tests/MooseSoft.Azure.ServiceBus.Tests/MooseSoft.Azure.ServiceBus.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />


### PR DESCRIPTION
Changes in 2.0.0
* Added ServiceBusPlugin to handle defer message failure policy and extension method to register the plugin.
* Added an optional should complete on exception func to MessageContextProcessor ctor that determines whether a message should be completed on an exception.
* ConstantBackOffDelayStrategy and ExponentialBackOffDelayStrategy have both had ctor removed that was no longer necessary.
* Reordered ctor params for failure policy classes to reflect likely usage.
* LinearBackOffDelayStrategy now accepts a TimeSpan as ctor argument instead of Int32 to give more flexibility.